### PR TITLE
Introduce response delay (reduce claude polling)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -360,7 +360,7 @@ class DeepseekClaudeServer {
         }
 
         // Otherwise, wait for either a status change or timeout
-        const POLL_DELAY_MS = 5000; // 5 second delay
+        const POLL_DELAY_MS = 10000; // 10 second delay
         const initialStatus = task.status;
         
         try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -342,15 +342,77 @@ class DeepseekClaudeServer {
           );
         }
 
+        // If task is in a final state (complete or error), return immediately
+        if (['complete', 'error'].includes(task.status)) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  status: task.status,
+                  reasoning: task.showReasoning ? task.reasoning : undefined,
+                  response: task.status === 'complete' ? task.response : undefined,
+                  error: task.error
+                })
+              }
+            ]
+          };
+        }
+
+        // Otherwise, wait for either a status change or timeout
+        const POLL_DELAY_MS = 5000; // 5 second delay
+        const initialStatus = task.status;
+        
+        try {
+          await new Promise((resolve, reject) => {
+            const checkInterval = setInterval(() => {
+              const currentTask = this.activeTasks.get(taskId);
+              if (!currentTask) {
+                clearInterval(checkInterval);
+                reject(new Error(`Task ${taskId} no longer exists`));
+                return;
+              }
+
+              // Resolve if status changed or reached final state
+              if (currentTask.status !== initialStatus || 
+                  currentTask.status === 'complete' || 
+                  currentTask.status === 'error') {
+                clearInterval(checkInterval);
+                resolve(true);
+              }
+            }, 100); // Check every 100ms for changes
+
+            // Set timeout to resolve after POLL_DELAY_MS
+            setTimeout(() => {
+              clearInterval(checkInterval);
+              resolve(false);
+            }, POLL_DELAY_MS);
+          });
+        } catch (error) {
+          throw new McpError(
+            ErrorCode.InvalidRequest,
+            error instanceof Error ? error.message : 'Unknown error occurred'
+          );
+        }
+
+        // Get final task state after waiting
+        const finalTask = this.activeTasks.get(taskId);
+        if (!finalTask) {
+          throw new McpError(
+            ErrorCode.InvalidRequest,
+            `Task ${taskId} no longer exists`
+          );
+        }
+
         return {
           content: [
             {
               type: 'text',
               text: JSON.stringify({
-                status: task.status,
-                reasoning: task.showReasoning ? task.reasoning : undefined,
-                response: task.status === 'complete' ? task.response : undefined,
-                error: task.error
+                status: finalTask.status,
+                reasoning: finalTask.showReasoning ? finalTask.reasoning : undefined,
+                response: finalTask.status === 'complete' ? finalTask.response : undefined,
+                error: finalTask.error
               })
             }
           ]


### PR DESCRIPTION
I had some issue's with it responding to quickly (go figure) and Claude then burning credits because it checks every second or so for a minute as OpenRouter is pretty slow for me. 

Added a reponse delay which acts a bit like reversed long-polling. If the status changes while in the delay, it returns immediately, same for final states.

Not sure everyone has this issue, but just in case, it helps a lot!

- Add 10-second delay for in-progress status checks 
- Return immediately for completed or error states 
- Check for status changes every 100ms during delay 
- Improve type safety for task status handling